### PR TITLE
Fix #13

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -61,6 +61,7 @@ Version: 2021-10-31
 
 .sidebar-tab .tab-content {
     overflow: hidden;
+    word-break: break-word;
     max-height: 0;
     -webkit-transition: max-height 0.35s;
     transition: max-height 0.35s;
@@ -115,7 +116,7 @@ Version: 2021-10-31
 
 .container {
     margin: 0 auto;
-    width: 1010px;
+    width: 1060px;
     display: -webkit-flex;
     display: flex;
 }


### PR DESCRIPTION
This fixes #13 and ID overflow problem (which was not reported as issue yet).
The following are the examples (from `2004.08500`) of before and after the fix.

#  Sidebar width

#13 was fixed by adjusting the container size (to be equal to main + sidebar+ margin).

## Before

![image](https://user-images.githubusercontent.com/52569097/183004249-07caf852-bb11-4deb-afc4-afa829f2280d.png)
![image](https://user-images.githubusercontent.com/52569097/183004330-7dbcea8d-617b-4b17-92fd-094c8e8a822a.png)


## After

![image](https://user-images.githubusercontent.com/52569097/183004608-2f885bab-b611-467e-8acc-56e34adfd632.png)
![image](https://user-images.githubusercontent.com/52569097/183004651-2e7e978e-51be-4dbe-b37d-3b317f95db53.png)


# ID overflow

ID overflow problem was fixed by adding "word-beak: breadk-word" to tab-content.

## Before

![image](https://user-images.githubusercontent.com/52569097/183003886-2d2ae4ce-7931-4699-a49a-b4b6f26edb46.png)

## After

![image](https://user-images.githubusercontent.com/52569097/183004697-96b7de24-9fb1-4707-b5d5-72501f841a3b.png)

