### PR TITLE
Updated Flask version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 docopt==0.6.2
-Flask==1.1.2
+Flask==2.2.3
 lxml==4.9.1
 matplotlib==3.2.1
 numpy==1.23.1


### PR DESCRIPTION
Older Flask version of 1.1.2 caused dependencies conflict with Werkzeug, Jinja2, markupsafe and other libraries. This could be fixed by either upgrading the version of Werkzeug and downgrading the version of Jinja2, or just by upgrading Flask to the latest version.