### PR TITLE
Feature/ar5iv_flow

### DIFF
--- a/tools/fetch_and_run.sh
+++ b/tools/fetch_and_run.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+arxiv_id=$1
+
+# Simply remove '/' to obtain paper_id from arxiv_id.
+paper_id=$(echo ${arxiv_id} | sed -e "s/\///g")
+
+arxmliv_dir="./arxmliv"
+template_dir="./templates"
+source_dir="./sources"
+
+# Exit when error occurs and show the commands to execute.
+set -e -x
+
+################
+## Fetch HTML ##
+################
+
+python -m tools.fetch_html --arxmliv-dir ${arxmliv_dir} ${arxiv_id}
+
+################
+## Preprocess ##
+################
+
+arxmliv_filename=${arxmliv_dir}/${paper_id}.html
+
+python -m tools.preprocess --data=${template_dir} --sources=${source_dir} ${arxmliv_filename}
+
+#########################
+## Run MioGatto Server ##
+#########################
+
+python -m server --data=${template_dir} --sources=${source_dir} ${paper_id}

--- a/tools/fetch_html.py
+++ b/tools/fetch_html.py
@@ -1,0 +1,125 @@
+# The preprocess tool for MioGatto
+import lxml.html
+import urllib.request
+from docopt import docopt
+from pathlib import Path
+
+from lib.version import VERSION
+from lib.logger import get_logger
+
+# meta
+PROG_NAME = "tools.fetch_html"
+HELP = """Fetch html file from ar5iv
+
+Usage:
+    {p} [options] ARXIVID
+
+Options:
+    --overwrite         Overwrite output files if already exist
+
+    --arxmliv-dir=DIR   Dir to save fetched html [default: ./arxmliv]
+
+    -D, --debug         Show debug messages
+    -q, --quiet         Show less messages
+
+    -h, --help          Show this screen and exit
+    -V, --version       Show version
+""".format(
+    p=PROG_NAME
+)
+
+logger = get_logger(PROG_NAME)
+
+
+def get_paper_id(arxiv_id: str) -> str:
+    # Simply remove the slash '/'.
+    return arxiv_id.replace('/', '')
+
+
+def get_html_tree(arxiv_id: str):
+    url: str = f"https://ar5iv.labs.arxiv.org/html/{arxiv_id}"
+
+    # To get formatted output html.
+    parser = lxml.html.HTMLParser(remove_blank_text=True)
+
+    with urllib.request.urlopen(url) as f:
+        tree = lxml.html.parse(f, parser=parser)
+
+    return tree
+
+
+def has_error(tree) -> bool:
+    root: lxml.html.HtmlElement = tree.getroot()
+
+    oks = root.xpath('//a[contains(@class, "ar5iv-severity-ok")]')
+    fatals = root.xpath('//a[contains(@class, "ar5iv-severity-fatal")]')
+
+    # Ad hoc.
+    if len(oks) == 1 and len(fatals) == 0:
+        # No error.
+        return False
+    elif len(oks) == 0 and len(fatals) == 1:
+        # There should have been an error in LaTeXML process.
+        return True
+    else:
+        # Something not expected, e.g., specification change, occurred.
+        logger.error("Something unexpected has occurred.")
+        exit(1)
+
+
+def clean_and_save(tree, output_file: Path):
+    root: lxml.html.HtmlElement = tree.getroot()
+
+    # Remove scripts.
+    for e in root.xpath('//script'):
+        e.drop_tree()
+
+    # Remove ar5iv related elements.
+    for e in root.xpath('//*[contains(@class, "ar5iv")]'):
+        e.drop_tree()
+
+    # Remove OGP info.
+    for e in root.xpath('/html/head/meta[contains(@name, "twitter") or contains(@property, "og")]'):
+        # e.drop_tag()
+        e.drop_tree()
+
+    # Remove link to css.
+    for e in root.xpath('/html/head/link'):
+        e.drop_tree()
+
+    logger.info(f"Saving the fetched html: {str(output_file)}")
+    tree.write(str(output_file), pretty_print=True, encoding='utf-8')
+
+
+def main():
+    # Parse options.
+    args = docopt(HELP, version=VERSION)
+
+    logger.set_logger(args['--quiet'], args['--debug'])
+
+    arxiv_id: str = args['ARXIVID']
+    # paper_id may not be equal to arxiv_id since the latter may contain '/', which is not problematic for filenames.
+    paper_id: str = get_paper_id(arxiv_id=arxiv_id)
+
+    arxmliv_dir: Path = Path(args['--arxmliv-dir'])
+    output_file: Path = arxmliv_dir.joinpath(f'{paper_id}.html')
+
+    # Prevent unintentional overwriting.
+    if args['--overwrite'] is not True:
+        if output_file.exists():
+            logger.error(f"Source file {str(output_file)} exists. Use --overwrite to force")
+            exit(1)
+
+    doc_tree = get_html_tree(arxiv_id=arxiv_id)
+
+    if has_error(tree=doc_tree):
+        # Exit if there is an error detedted in the fetched html.
+        logger.error(f'Fetch failed; Error should have occurred during applying LaTeXML to {arxiv_id}')
+        exit(1)
+    else:
+        # Save the fetched html.
+        clean_and_save(tree=doc_tree, output_file=output_file)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
I added two scripts:

1. `tools/fetch_html.py`:
    - Fetch LaTeXML-processed HTML from ar5iv.
    - It also cleans the html by removing unnecessary elements, e.g., `script`.
2.  `tools/fetch_and_run.sh`:
    - Sequentially execute `tools/fetch_html.py`, `tools/preprocess.py`, and `server/__main__.py`.
    - All the internal commands use the default options (including the directories, e.g., `./arxmliv`, `./templates`, and `./sources`.
    - If an error occurs in one of the steps, the script immediately exists with the same exit code as the internal script.
    - Note that, if there already exists one of,  `./arxmliv/${paper_id}.html`, `./sources/${paper_id}.html`, this script (preciesely, the internal fetch_html and preprocess script) exits immediately.

The script can be used as follows:
```
$ bash ./tools/fetch_and_run.html
```